### PR TITLE
src/def.h: fix build with gcc 10

### DIFF
--- a/src/def.h
+++ b/src/def.h
@@ -650,7 +650,7 @@ int		 excline(char *);
 char		*skipwhite(char *);
 
 /* help.c X */
-const char	*hlp;
+extern const char	*hlp;
 int		 desckey(int, int);
 int		 wallchart(int, int);
 int		 help_help(int, int);


### PR DESCRIPTION
Define hlp as extern to avoid the following build failure with gcc 10
(which defaults to -fno-common):

```
  CCLD     mg
/home/buildroot/autobuild/run/instance-1/output-1/host/lib/gcc/arm-buildroot-linux-gnueabihf/10.2.0/../../../../arm-buildroot-linux-gnueabihf/bin/ld: mg-bell.o:(.bss+0x0): multiple definition of `hlp'; mg-basic.o:(.bss+0x0): first defined here
```

Fixes:
 - http://autobuild.buildroot.org/results/aacc02abf41e120e0d0b22faa38642e6d149d73f

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>