### PR TITLE
Fix revertbuffer crash on mac, due to mem overlap

### DIFF
--- a/src/buffer.c
+++ b/src/buffer.c
@@ -958,6 +958,7 @@ dorevert(void)
 {
 	int lineno;
 	struct undo_rec *rec;
+	char fname[NFILEN];
 
 	if (access(curbp->b_fname, F_OK|R_OK) != 0) {
 		dobeep();
@@ -982,7 +983,10 @@ dorevert(void)
 		free_undo_record(rec);
 	}
 
-	if (readin(curbp->b_fname))
+	/* don't use curbp->b_fname as src and dist of filename, causes mem overlap */
+	strlcpy(fname, curbp->b_fname, sizeof(fname));
+
+	if (readin(fname))
 		return(setlineno(lineno));
 	return (FALSE);
 }


### PR DESCRIPTION
revertbuffer crashes on Mac, the reason because the mem overlap happens when sending curbp->b_fname, as the new file to open, which it's also the destination, that happens in `insertfile` when calling `(void)strlcpy(bp->b_fname, newname, sizeof(bp->b_fname));`

following traceback using lldb:

```
* thread #1, queue = 'com.apple.main-thread', stop reason = EXC_BREAKPOINT (code=1, subcode=0x1b3acd99c)
    frame #0: 0x00000001b3acd99c libsystem_c.dylib`__chk_fail_overlap + 24
libsystem_c.dylib`:
->  0x1b3acd99c <+24>: brk    #0x1

libsystem_c.dylib`:
    0x1b3acd9a0 <+0>:  pacibsp
    0x1b3acd9a4 <+4>:  stp    x22, x21, [sp, #-0x30]!
    0x1b3acd9a8 <+8>:  stp    x20, x19, [sp, #0x10]
Target 0: (mg) stopped.
```