### PR TITLE
New command apply-macro-to-region-lines

### DIFF
--- a/src/def.h
+++ b/src/def.h
@@ -764,6 +764,7 @@ int		 showversion(int, int);
 int		 definemacro(int, int);
 int		 finishmacro(int, int);
 int		 executemacro(int, int);
+int		 applymacro(int, int);
 
 /* modes.c X */
 int		 indentmode(int, int);

--- a/src/funmap.c
+++ b/src/funmap.c
@@ -60,6 +60,7 @@ static struct funmap functnames[] = {
 	{NULL, "c-x 4 prefix", 0, NULL},
 	{NULL, "c-x prefix", 0, NULL},
 	{executemacro, "call-last-kbd-macro", 0, NULL},
+	{applymacro, "apply-macro-to-region-lines", 0, NULL},
 	{capword, "capitalize-word", 1, NULL},
 	{changedir, "cd", 0, NULL},
 	{clearmark, "clear-mark", 0, NULL},

--- a/src/macro.c
+++ b/src/macro.c
@@ -106,3 +106,53 @@ executemacro(int f, int n)
 	inmacro = FALSE;
 	return (TRUE);
 }
+
+int
+applymacro(int f, int n)
+{
+	struct line	*odotp, *omarkp, *tmarkp;
+	int	odoto, odotline, omarko, omarkline, tmarko, tmarkline;
+
+	if (curwp->w_markp == NULL) {
+		dobeep();
+		ewprintf("No mark set in this window");
+		return (FALSE);
+	}
+
+	/* (save-mark-and-excursion) save the state of the "." and mark */
+	odotp = curwp->w_dotp;
+	omarkp = curwp->w_markp;
+	odoto = curwp->w_doto;
+	odotline = curwp->w_dotline;
+	omarko = curwp->w_marko;
+	omarkline = curwp->w_markline;
+
+	if (curwp->w_dotline > curwp->w_markline) {
+		swapmark(FFRAND, 0);
+	}
+
+	tmarkp = curwp->w_markp;
+	tmarko = curwp->w_marko;
+	tmarkline = curwp->w_markline;
+
+	while (curwp->w_dotline < curwp->w_markline) {
+		gotobol(FFRAND, 1);
+		executemacro(FFRAND, 1);
+		forwline(FFRAND, 1);
+
+		/* restore mark that may have been altered by the executed macro */
+		curwp->w_markp = tmarkp;
+		curwp->w_marko = tmarko;
+		curwp->w_markline = tmarkline;
+	}
+
+	/* (save-mark-and-excursion) restore the state of the "." and mark */
+	curwp->w_dotp = odotp;
+	curwp->w_doto = odoto;
+	curwp->w_dotline = odotline;
+	curwp->w_markp = omarkp;
+	curwp->w_marko = omarko;
+	curwp->w_markline = omarkline;
+
+	return (TRUE);
+}


### PR DESCRIPTION
apply-macro-to-region-lines applies a recorded kbd macro to each line in the region.

https://github.com/troglobit/mg/assets/29784485/71ac18a7-b0cc-4dec-b3f4-eba69f2c6096

NOTE: This function does not work properly when the region is activated with M-h (markpara). I looked into it and it looks like markpara makes curwp->w_markline and curwp->w_marko both 0, when I don't think it should. I am not sure why this happens, but I will look into it later to see if it is something on my end.