### PR TITLE
Set `curwp->w_markline` after `clearmark` in `markpara`

### DIFF
--- a/src/paragraph.c
+++ b/src/paragraph.c
@@ -311,6 +311,7 @@ markpara(int f, int n)
 	/* set the mark here */
 	curwp->w_markp = curwp->w_dotp;
 	curwp->w_marko = curwp->w_doto;
+	curwp->w_markline = curwp->w_dotline;
 
 	(void)gotobop(FFRAND, i);
 


### PR DESCRIPTION
Fixes bug where the current markline is not reset after being cleared.

This makes it possible to now mark a region, and use `apply-macro-to-region-lines` since the markline is now set in the correct position:

https://github.com/troglobit/mg/assets/29784485/33e71af8-0cea-4d6a-a73a-22c7f4e668e8