### PR TITLE
Fix build when dired disabled

### DIFF
--- a/src/funmap.c
+++ b/src/funmap.c
@@ -102,7 +102,9 @@ static struct funmap functnames[] = {
 	{desckey, "describe-key-briefly", 1, NULL},
 	{diffbuffer, "diff-buffer-with-file", 0, NULL},
 	{digit_argument, "digit-argument", 1, NULL},
+#ifdef ENABLE_DIRED
 	{dired_jump, "dired-jump", 1, NULL},
+#endif
 	{helptoggle, "display-help-mode", 0, NULL},
 	{timetoggle, "display-time-mode", 0, NULL},
 	{lowerregion, "downcase-region", 0, NULL},

--- a/src/keymap.c
+++ b/src/keymap.c
@@ -157,7 +157,9 @@ static PF cXcB[] = {
 };
 
 static PF cXcJ[] = {
+#ifdef ENABLE_DIRED
 	dired_jump,		/* ^J */
+#endif
 	rescan,			/* ^K */
 	lowerregion,		/* ^L */
 	rescan,			/* ^M */


### PR DESCRIPTION
* src/def.h:
* src/dired.c:
* src/funmap.c:
* src/keymap.c: Guard references to `dired_jump` function and its implementation behind `ENABLE_DIRED` preprocessor maco.

Fixes the following linker error when building with `--disable-dired` configuration option and those that imply it.

```
/usr/bin/ld: /tmp/branden/mg.E83i08.ltrans0.ltrans.o:(.data.rel.cXcJ+0x0): undefined reference to `dired_jump'
/usr/bin/ld: /tmp/branden/mg.E83i08.ltrans0.ltrans.o:(.data.rel.functnames+0x480): undefined reference to `dired_jump'
collect2: error: ld returned 1 exit status
```