### PR TITLE
feat: Add Lua scripting and Vim keybindings

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -74,6 +74,32 @@ AC_ARG_WITH(tutorial,
      AS_HELP_STRING([--without-tutorial], [Skip installation of $datadir/mg/tutorial.gz]),
      [with_tutorial=$withval], [with_tutorial='yes'])
 
+AC_ARG_WITH(lua,
+     AS_HELP_STRING([--with-lua], [Enable LUA scripting support.]),
+     [], [with_lua=no])
+
+# Check for LUA
+AS_IF([test "x$with_lua" != "xno"], [
+   PKG_CHECK_MODULES([LUA], [lua5.3], [have_lua=yes], [
+   PKG_CHECK_MODULES([LUA], [lua-5.3], [have_lua=yes], [
+   PKG_CHECK_MODULES([LUA], [lua5.2], [have_lua=yes], [
+   PKG_CHECK_MODULES([LUA], [lua-5.2], [have_lua=yes], [
+   PKG_CHECK_MODULES([LUA], [lua5.1], [have_lua=yes], [
+   PKG_CHECK_MODULES([LUA], [lua-5.1], [have_lua=yes], [
+   PKG_CHECK_MODULES([LUA], [lua], [have_lua=yes], [
+      have_lua=no
+   ])])])])])])])
+   AS_IF([test "x$have_lua" = "xyes"], [
+      AC_DEFINE(HAVE_LUA, 1, [Have LUA library])
+   ], [
+      AS_IF([test "x$with_lua" = "xyes"], [
+         AC_MSG_ERROR([LUA support explicitly requested, but libraries not found.])
+      ])
+   ])
+])
+AC_SUBST(LUA_CFLAGS)
+AC_SUBST(LUA_LIBS)
+
 # Check for a termcap compatible library
 AS_IF([test "x$with_curses" = "xyes" -o "x$with_curses" = "xauto"], [
 	AC_CHECK_LIB(ncurses, tgoto, , [
@@ -170,6 +196,7 @@ AM_CONDITIONAL(MGLOG,    [test "x$with_mglog"     != "xno"])
 AM_CONDITIONAL(DOCS,     [test "x$with_docs"      != "xno"])
 AM_CONDITIONAL(NOCURSES, [test "x$with_curses"     = "xno"])
 AM_CONDITIONAL(TUTOR,    [test "x$with_tutorial"  != "xno"])
+AM_CONDITIONAL(LUA,      [test "x$have_lua"        = "xyes"])
 
 # Generate all files
 AC_OUTPUT
@@ -208,6 +235,7 @@ cat <<EOF
   ctags..........: $enable_ctags
   dired..........: $enable_dired
   regexp.........: $enable_regexp
+  lua............: $with_lua
 
 ------------- Compiler version --------------
 $($CC --version || true)

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -53,6 +53,12 @@ if MGLOG
 mg_SOURCES     += log.c log.h
 endif
 
+if LUA
+mg_SOURCES     += lua.c
+mg_CFLAGS      += $(LUA_CFLAGS)
+mg_LDADD       += $(LUA_LIBS)
+endif
+
 #
 # Building w/o terminfo/termcap/curses/ncurses
 #

--- a/src/def.h
+++ b/src/def.h
@@ -882,3 +882,8 @@ extern int		 rptcount;	/* successive invocation count */
  */
 extern int		 shownlprompt;
 int			 togglenewlineprompt(int, int);
+
+#ifdef HAVE_LUA
+/* lua.c */
+void		 lua_init(void);
+#endif /* HAVE_LUA */

--- a/src/kbd.h
+++ b/src/kbd.h
@@ -52,6 +52,8 @@ struct maps_s	*name_mode(const char *);
 PF		 doscan(KEYMAP *, int, KEYMAP **);
 void		 maps_init(void);
 int		 maps_add(KEYMAP *, const char *);
+struct maps_s	*name_mode(const char *);
+void             lua_eval_file(const char *);
 
 extern struct map_element	*ele;
 extern struct maps_s		*defb_modes[];

--- a/src/lua.c
+++ b/src/lua.c
@@ -1,0 +1,290 @@
+/*
+ * This file is in the public domain.
+ *
+ * Author: Jules
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include "def.h"
+#include "funmap.h"
+#include "kbd.h"
+
+#ifdef HAVE_LUA
+#include <lua.h>
+#include <lauxlib.h>
+#include <lualib.h>
+
+#define MAX_LUA_CMDS 32
+
+static lua_State *L = NULL;
+static int lua_fn_refs[MAX_LUA_CMDS];
+static int next_lua_fn_ref = 0;
+
+/* Forward declarations */
+int eval_lua_file_cmd(int, int);
+
+/*
+ * Dispatcher functions.
+ */
+#define LUA_CMD_FN(n) \
+static int lua_cmd_ ## n(int f, int n_arg) { \
+    if (L == NULL || lua_fn_refs[n] == LUA_REFNIL) return FALSE; \
+    lua_rawgeti(L, LUA_REGISTRYINDEX, lua_fn_refs[n]); \
+    if (lua_pcall(L, 0, 0, 0) != LUA_OK) { \
+        dobeep(); \
+        ewprintf("Lua error: %s", lua_tostring(L, -1)); \
+        lua_pop(L, 1); \
+        return FALSE; \
+    } \
+    return TRUE; \
+}
+
+/* Generate the dispatcher functions */
+LUA_CMD_FN(0) LUA_CMD_FN(1) LUA_CMD_FN(2) LUA_CMD_FN(3)
+LUA_CMD_FN(4) LUA_CMD_FN(5) LUA_CMD_FN(6) LUA_CMD_FN(7)
+LUA_CMD_FN(8) LUA_CMD_FN(9) LUA_CMD_FN(10) LUA_CMD_FN(11)
+LUA_CMD_FN(12) LUA_CMD_FN(13) LUA_CMD_FN(14) LUA_CMD_FN(15)
+LUA_CMD_FN(16) LUA_CMD_FN(17) LUA_CMD_FN(18) LUA_CMD_FN(19)
+LUA_CMD_FN(20) LUA_CMD_FN(21) LUA_CMD_FN(22) LUA_CMD_FN(23)
+LUA_CMD_FN(24) LUA_CMD_FN(25) LUA_CMD_FN(26) LUA_CMD_FN(27)
+LUA_CMD_FN(28) LUA_CMD_FN(29) LUA_CMD_FN(30) LUA_CMD_FN(31)
+
+static PF lua_cmd_fns[] = {
+    lua_cmd_0, lua_cmd_1, lua_cmd_2, lua_cmd_3,
+    lua_cmd_4, lua_cmd_5, lua_cmd_6, lua_cmd_7,
+    lua_cmd_8, lua_cmd_9, lua_cmd_10, lua_cmd_11,
+    lua_cmd_12, lua_cmd_13, lua_cmd_14, lua_cmd_15,
+    lua_cmd_16, lua_cmd_17, lua_cmd_18, lua_cmd_19,
+    lua_cmd_20, lua_cmd_21, lua_cmd_22, lua_cmd_23,
+    lua_cmd_24, lua_cmd_25, lua_cmd_26, lua_cmd_27,
+    lua_cmd_28, lua_cmd_29, lua_cmd_30, lua_cmd_31,
+};
+
+/*
+ * Lua-callable function to define a new mg command.
+ * mg.defun("my-command", function() ... end)
+ */
+static int
+l_defun(lua_State *ls)
+{
+    const char *name;
+    int fun_ref;
+
+    if (next_lua_fn_ref >= MAX_LUA_CMDS) {
+        lua_pushstring(ls, "Too many Lua commands defined");
+        lua_error(ls);
+        return 0;
+    }
+
+    name = luaL_checkstring(ls, 1);
+    luaL_checktype(ls, 2, LUA_TFUNCTION);
+
+    lua_pushvalue(ls, 2);
+    fun_ref = luaL_ref(ls, LUA_REGISTRYINDEX);
+
+    lua_fn_refs[next_lua_fn_ref] = fun_ref;
+    funmap_add(lua_cmd_fns[next_lua_fn_ref], name, 0);
+
+    next_lua_fn_ref++;
+
+    return 0;
+}
+
+/*
+ * mg.bind_key("map_name", "key", "function_name")
+ */
+static int
+l_bind_key(lua_State *ls)
+{
+    const char *map_name, *key, *func_name;
+    KEYMAP *map;
+
+    map_name = luaL_checkstring(ls, 1);
+    key = luaL_checkstring(ls, 2);
+    func_name = luaL_checkstring(ls, 3);
+
+    map = name_map(map_name);
+    if (map == NULL) {
+        lua_pushstring(ls, "Unknown keymap");
+        lua_error(ls);
+        return 0;
+    }
+
+    if (dobindkey(map, func_name, key) != TRUE) {
+        lua_pushstring(ls, "Failed to bind key");
+        lua_error(ls);
+        return 0;
+    }
+
+    return 0;
+}
+
+/*
+ * mg.new_keymap("map_name")
+ */
+static int
+l_new_keymap(lua_State *ls)
+{
+    const char *name;
+    KEYMAP *map;
+
+    name = luaL_checkstring(ls, 1);
+
+    map = malloc(sizeof(KEYMAP) + (MAPINIT - 1) * sizeof(struct map_element));
+    if (map == NULL) {
+        lua_pushstring(ls, "Out of memory");
+        lua_error(ls);
+        return 0;
+    }
+    map->map_num = 0;
+    map->map_max = MAPINIT;
+    map->map_default = rescan; /* Default to rescan for new maps */
+
+    if (maps_add(map, name) != TRUE) {
+        free(map);
+        lua_pushstring(ls, "Failed to add keymap");
+        lua_error(ls);
+        return 0;
+    }
+
+    return 0;
+}
+
+/*
+ * mg.set_mode("mode_name")
+ */
+static int
+l_set_mode(lua_State *ls)
+{
+    const char *mode_name;
+    struct maps_s *mp;
+
+    mode_name = luaL_checkstring(ls, 1);
+    mp = name_mode(mode_name);
+
+    if (mp == NULL) {
+        lua_pushstring(ls, "Unknown mode");
+        lua_error(ls);
+        return 0;
+    }
+
+    /* For simplicity, we only support one mode for now. */
+    curbp->b_nmodes = 0;
+    curbp->b_modes[0] = mp;
+    curwp->w_flag |= WFMODE;
+
+    return 0;
+}
+
+
+/*
+ * Wrapper functions to be called from Lua.
+ */
+
+static int
+lua_forwchar(lua_State *ls)
+{
+    forwchar(0, 1);
+    return 0;
+}
+
+static int
+lua_backchar(lua_State *ls)
+{
+    backchar(0, 1);
+    return 0;
+}
+
+static int
+lua_forwline(lua_State *ls)
+{
+    forwline(0, 1);
+    return 0;
+}
+
+static int
+lua_backline(lua_State *ls)
+{
+    backline(0, 1);
+    return 0;
+}
+
+/*
+ * The 'mg' module definition for Lua.
+ */
+static const struct luaL_Reg mglib[] = {
+    {"defun", l_defun},
+    {"bind_key", l_bind_key},
+    {"new_keymap", l_new_keymap},
+    {"set_mode", l_set_mode},
+    {"forwchar", lua_forwchar},
+    {"backchar", lua_backchar},
+    {"forwline", lua_forwline},
+    {"backline", lua_backline},
+    {NULL, NULL} /* Sentinel */
+};
+
+/*
+ * Load and execute a Lua file.
+ */
+void
+lua_eval_file(const char *filename)
+{
+    if (L == NULL) {
+        dobeep_msg("Lua not initialized");
+        return;
+    }
+    if (luaL_dofile(L, filename)) {
+        dobeep();
+        ewprintf("Lua error: %s", lua_tostring(L, -1));
+        lua_pop(L, 1); /* pop error message */
+    }
+}
+
+/*
+ * mg command to evaluate a Lua file.
+ */
+int
+eval_lua_file_cmd(int f, int n)
+{
+    char filename[NFILEN];
+
+    if (eread("Eval Lua file: ", filename, NFILEN, EFNEW | EFCR) == NULL)
+        return (ABORT);
+    if (filename[0] == '\0')
+        return (FALSE);
+
+    lua_eval_file(filename);
+
+    return (TRUE);
+}
+
+/*
+ * Initialize the Lua interpreter and create the 'mg' module.
+ */
+void
+lua_init(void)
+{
+    int i;
+
+    L = luaL_newstate();
+    if (L == NULL) {
+        dobeep_msg("Failed to initialize Lua");
+        return;
+    }
+    luaL_openlibs(L);
+
+    for (i = 0; i < MAX_LUA_CMDS; i++) {
+        lua_fn_refs[i] = LUA_REFNIL;
+    }
+
+    /* Create the 'mg' module */
+    luaL_newlib(L, mglib);
+    lua_setglobal(L, "mg");
+
+    /* Register the eval-lua-file command */
+    funmap_add(eval_lua_file_cmd, "eval-lua-file", 1);
+}
+
+#endif /* HAVE_LUA */

--- a/src/main.c
+++ b/src/main.c
@@ -124,6 +124,10 @@ main(int argc, char **argv)
 	maps_init();		/* Keymaps and modes.		*/
 	funmap_init();		/* Functions.			*/
 
+#ifdef HAVE_LUA
+	lua_init();
+#endif /* HAVE_LUA */
+
 #ifdef  MGLOG
 	if (!mgloginit())
 		errx(1, "Unable to create logging environment.");
@@ -172,6 +176,12 @@ main(int argc, char **argv)
 		(void)load(ffp, file);
 		ffclose(ffp, NULL);
 	}
+
+#ifdef HAVE_LUA
+    if (access("vim.lua", F_OK) == 0) {
+        lua_eval_file("vim.lua");
+    }
+#endif
 
 	if (batch) {
 		vttidy();

--- a/test.lua
+++ b/test.lua
@@ -1,0 +1,11 @@
+-- test.lua
+--
+-- A simple script to test the mg.defun function.
+
+function my_test_command()
+    mg.forwline()
+    mg.forwline()
+    mg.forwchar()
+end
+
+mg.defun("my-test-command", my_test_command)

--- a/test.mg
+++ b/test.mg
@@ -1,0 +1,2 @@
+eval-lua-file "test.lua"
+my-test-command

--- a/vim.lua
+++ b/vim.lua
@@ -1,0 +1,45 @@
+-- vim.lua
+--
+-- This script configures mg to use vim-like keybindings.
+
+-- Define a new keymap for normal mode
+mg.new_keymap("vim-normal")
+
+-- Define functions for normal mode commands
+function vim_move_left() mg.backchar() end
+function vim_move_down() mg.forwline() end
+function vim_move_up() mg.backline() end
+function vim_move_right() mg.forwchar() end
+
+function vim_insert_mode()
+    mg.set_mode("fundamental")
+end
+
+-- Register the functions as mg commands
+mg.defun("vim-move-left", vim_move_left)
+mg.defun("vim-move-down", vim_move_down)
+mg.defun("vim-move-up", vim_move_up)
+mg.defun("vim-move-right", vim_move_right)
+mg.defun("vim-insert-mode", vim_insert_mode)
+
+-- Bind keys in the normal mode map
+mg.bind_key("vim-normal", "h", "vim-move-left")
+mg.bind_key("vim-normal", "j", "vim-move-down")
+mg.bind_key("vim-normal", "k", "vim-move-up")
+mg.bind_key("vim-normal", "l", "vim-move-right")
+mg.bind_key("vim-normal", "i", "vim-insert-mode")
+
+-- Define a function to enter normal mode
+function vim_normal_mode()
+    mg.set_mode("vim-normal")
+end
+
+-- Register the normal mode command
+mg.defun("vim-normal-mode", vim_normal_mode)
+
+-- Bind ESC in the fundamental map to enter normal mode
+-- The escape key is represented as '^[', which is CCHR('[')
+mg.bind_key("fundamental", "^[", "vim-normal-mode")
+
+-- Enter normal mode by default
+vim_normal_mode()


### PR DESCRIPTION
This commit introduces a Lua scripting interface to the mg editor and uses it to implement optional Vim-like keybindings.

The core of this change is a new C-to-Lua bridge that allows Lua scripts to:
- Define new editor commands.
- Create new keymaps.
- Bind keys to commands in any keymap.
- Set the active keymap for the current buffer.
- Call core editor functions (e.g., for character and line movement).

A `vim.lua` script is included that uses this new API to create a "vim-normal" mode. When this script is present, it will be loaded at startup, and the editor will default to normal mode with the following bindings:
- h, j, k, l: for movement
- i: to enter insert mode (the default mg keymap)
- ESC: to return to normal mode from insert mode

To enable this feature, build with the `--with-lua` flag and ensure `vim.lua` is in the working directory.