### PR TITLE
Add use-short-answers option like in Gnu Emacs

### DIFF
--- a/doc/mg.1
+++ b/doc/mg.1
@@ -986,6 +986,9 @@ Execute external command from mini-buffer.  With a universal argument
 Provide the text in region to the shell command as input.  With a
 universal argument (C-u), this command replaces the marked region
 with the output from the command.
+.It Ic use-short-answers
+Toggle short answers for important questions. When enabled,
+y and n are accepted instead of yes and no.
 .It Ic shrink-window
 Shrink current window by one line.
 The window immediately below is expanded to pick up the slack.

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -24,6 +24,8 @@ static struct buffer *bnew(const char *);
 
 static int usebufname(const char *);
 
+static int shortanswers = 0;
+
 /* Default tab width */
 int	 defb_tabw = 8;
 
@@ -658,10 +660,11 @@ bclear(struct buffer *bp)
 {
 	struct line	*lp;
 	int		 s;
+    int		(*q)(const char *) = shortanswers ? eyorn : eyesno;
 
 	/* Has buffer changed, and do we care? */
 	if (!(bp->b_flag & BFIGNDIRTY) && (bp->b_flag & BFCHG) != 0 &&
-	    (s = eyesno("Buffer modified; kill anyway")) != TRUE)
+	    (s = q("Buffer modified; kill anyway")) != TRUE)
 		return (s);
 	bp->b_flag &= ~BFCHG;	/* Not changed		 */
 	while ((lp = lforw(bp->b_headp)) != bp->b_headp)
@@ -1110,4 +1113,16 @@ findbuffer(char *fn)
 
 	bp = bfind(bname, TRUE);
 	return (bp);
+}
+
+/*
+ * Toggle shortanswers like in Gnu emacs: no yes or no questions,
+ * only y or n
+ */
+int
+useshortanswers(int f, int n)
+{
+	shortanswers = !shortanswers;
+
+	return (TRUE);
 }

--- a/src/def.h
+++ b/src/def.h
@@ -584,6 +584,7 @@ int		 fchecktime(struct buffer *);
 int		 fupdstat(struct buffer *);
 int		 backuptohomedir(int, int);
 int		 toggleleavetmp(int, int);
+int          useshortanswers(int, int);
 char		*expandtilde(const char *);
 
 /* kbd.c X */

--- a/src/funmap.c
+++ b/src/funmap.c
@@ -50,6 +50,7 @@ static struct funmap functnames[] = {
 	{backtoindent, "back-to-indentation", 0, NULL},
 	{backuptohomedir, "backup-to-home-directory", 0, NULL},
 	{backchar, "backward-char", 1, NULL},
+    {useshortanswers, "use-short-answers", 0, NULL},
 	{delbword, "backward-kill-word", 1, NULL},
 	{gotobop, "backward-paragraph", 1, NULL},
 	{backword, "backward-word", 1, NULL},


### PR DESCRIPTION
This adds a use-short-answers command to toggle short y/n answers for yes-or-no prompts.

The option is documented in the manual and can be enabled from .mg.